### PR TITLE
Fix: Add Git installation to Dockerfile to resolve GitPython dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
+# Install system dependencies including Git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy requirements first for better caching
 COPY requirements.txt .
 
@@ -26,6 +32,7 @@ ENV STREAMLIT_SERVER_HEADLESS=true
 ENV LOG_DIR=/app/logs
 ENV CACHE_FILE=/app/llm_cache.json
 ENV CACHE_ENABLED=true
+ENV GIT_PYTHON_REFRESH=quiet
 
 # Command to run the Streamlit app
 CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
This PR fixes an issue with the Docker image where the GitPython library fails to initialize due to missing Git executable.

Changes:
- Added Git installation to the Dockerfile using apt-get
- Added GIT_PYTHON_REFRESH=quiet environment variable to suppress unnecessary warnings

This fix ensures that the application can run properly in Docker containers without the "Failed to initialize: Bad git executable" error.